### PR TITLE
Dynamic sizing of the bottom sheet modal with less models

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -12,6 +12,7 @@ import { Model } from './types'
 import { ActionSheetProvider } from '@expo/react-native-action-sheet'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import {
+  BottomSheetBackdrop,
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetView,
@@ -68,8 +69,7 @@ export default function App() {
 
   function handlePresentModalPress() {
     if (modalVisible) {
-      bottomSheetModalRef.current?.dismiss()
-      setModalVisible(false)
+      closeModal()
     } else {
       bottomSheetModalRef.current?.present()
       setModalVisible(true)
@@ -125,11 +125,10 @@ export default function App() {
                 backgroundStyle={bottomSheetStyles.background}
                 ref={bottomSheetModalRef}
                 enableDynamicSizing={true}
-                onChange={
-                  (index) => {
-                    if (index === -1) setModalVisible(false)
-                  }
-                }
+                backdropComponent={(props) => <BottomSheetBackdrop {...props}  disappearsOnIndex={-1}/>}
+                enableDismissOnClose
+                enablePanDownToClose
+                onDismiss={() => setModalVisible(false)}
               >
                 <BottomSheetView>
                   <ChatModelModal

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -14,6 +14,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import {
   BottomSheetModal,
   BottomSheetModalProvider,
+  BottomSheetView,
 } from '@gorhom/bottom-sheet'
 import { StyleSheet } from 'react-native'
 import LogBox from 'react-native/Libraries/LogBox/LogBox'
@@ -123,16 +124,18 @@ export default function App() {
                 handleStyle={bottomSheetStyles.handle}
                 backgroundStyle={bottomSheetStyles.background}
                 ref={bottomSheetModalRef}
-                snapPoints={['50%']}
+                enableDynamicSizing={true}
                 onChange={
                   (index) => {
                     if (index === -1) setModalVisible(false)
                   }
                 }
               >
-                <ChatModelModal
-                  handlePresentModalPress={handlePresentModalPress}
-                />
+                <BottomSheetView>
+                  <ChatModelModal
+                    handlePresentModalPress={handlePresentModalPress}
+                  />
+                </BottomSheetView>
               </BottomSheetModal>
             </BottomSheetModalProvider>
         </ThemeContext.Provider>

--- a/app/src/components/ChatModelModal.tsx
+++ b/app/src/components/ChatModelModal.tsx
@@ -73,7 +73,6 @@ function getStyles(theme) {
     bottomSheetContainer: {
       borderColor: theme.borderColor,
       borderWidth: 1,
-      flex: 1,
       padding: 24,
       justifyContent: 'center',
       backgroundColor: theme.backgroundColor,


### PR DESCRIPTION
In case when user choose to use only a subset of chat models, BottomSheet modal should resize automatically to fit the new list.
This PR is going to take advantage of `enableDynamicSizing` prop that's now available to [@gorhom/bottom-sheet 4.5.0+](https://github.com/gorhom/react-native-bottom-sheet/releases/tag/v4.5.0)

Here's a quick demo of how things are going to act based on the `ChatModels` list selection



https://github.com/dabit3/react-native-ai/assets/2805320/71568924-490f-4dfa-92fd-c808051467f3


---
Backdrop

| Dark | Hacker news | Light | Miami | Vercel |
|--------|--------|--------|--------|--------|
| ![dark](https://github.com/dabit3/react-native-ai/assets/2805320/e184bfeb-5993-419c-9168-4816b5db2f99) | ![hacker news](https://github.com/dabit3/react-native-ai/assets/2805320/6d0014ea-82b4-49db-8fb5-8df78975e6ea) | ![light](https://github.com/dabit3/react-native-ai/assets/2805320/1e8f012b-1eec-49f0-8a72-f795864fcce8) | ![miami](https://github.com/dabit3/react-native-ai/assets/2805320/4fb26f5f-324d-47ea-bf22-cf8524223b96) | ![vercel](https://github.com/dabit3/react-native-ai/assets/2805320/d1945fbe-c744-4dc2-aa38-0e52f2d92248) | 

Backdrop behaviour video:


https://github.com/dabit3/react-native-ai/assets/2805320/047b51d2-6402-4b8f-bbff-b4c681d5f68e


