### PR TITLE
Add Matrix theme with black and green color scheme

### DIFF
--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -7,7 +7,10 @@ const colors = {
   lightPink: '#F7B5CD',
   neonCyan: '#00f0ff',
   neonMagenta: '#ff00ff',
-  cyberpunkDark: '#0d0221'
+  cyberpunkDark: '#0d0221',
+  matrixGreen: '#00ff41',
+  matrixDarkGreen: '#003b00',
+  matrixBlack: '#0d0d0d'
 }
 
 const fonts = {
@@ -97,6 +100,18 @@ const cyberpunk = {
   borderColor: 'rgba(0, 240, 255, .3)',
 }
 
+const matrix = {
+  ...darkTheme,
+  name: 'Matrix',
+  label: 'matrix',
+  backgroundColor: colors.matrixBlack,
+  tintColor: colors.matrixGreen,
+  tintTextColor: colors.matrixBlack,
+  tabBarActiveTintColor: colors.matrixGreen,
+  tabBarInactiveTintColor: colors.matrixDarkGreen,
+  borderColor: 'rgba(0, 255, 65, .3)',
+}
+
 export {
-  lightTheme, darkTheme, hackerNews, miami, vercel, cyberpunk
+  lightTheme, darkTheme, hackerNews, miami, vercel, cyberpunk, matrix
 }


### PR DESCRIPTION
## Summary

Adds a new "Matrix" theme inspired by the classic Matrix movie aesthetic. The theme features a dark black background with bright neon green accents, following the same pattern as existing themes like Cyberpunk and Miami.

New colors added:
- `matrixGreen` (#00ff41) - bright neon green for primary accents
- `matrixDarkGreen` (#003b00) - darker green for inactive elements
- `matrixBlack` (#0d0d0d) - near-black background

The theme extends `darkTheme` and will automatically appear in the Settings screen theme picker.

## Review & Testing Checklist for Human

- [ ] Run the app and select the Matrix theme from Settings to verify it looks visually appealing
- [ ] Check that text is readable against the dark background (contrast ratio)
- [ ] Verify the tab bar active/inactive states look correct with the green colors

### Test Plan
1. Start the app with `pnpm start` in the `/app` directory
2. Navigate to Settings tab
3. Select "Matrix" from the theme list
4. Navigate through Chat, Images, and Settings tabs to verify the theme applies consistently

### Notes
- The theme was not visually tested during development as the React Native environment wasn't fully set up
- Requested by @dabit3
- Link to Devin run: https://app.devin.ai/sessions/9754891a03754e22aff8c64366d5a00a